### PR TITLE
Added 'acl' package for F36+ systems

### DIFF
--- a/provisioning/roles/early_packages/vars/main.yml
+++ b/provisioning/roles/early_packages/vars/main.yml
@@ -18,6 +18,12 @@ _early_packages:
     - python3-libselinux
     - python3-policycoreutils
 
+  # Fedora 36 and up
+  - Fedora([1-9][0-9]{2,}|3[6-9]|[4-9][0-9]):
+    # 'acl' is required to allow us to deploy files as an unprivileged user for
+    # another unprivileged user.
+    - acl
+
   ##########################################################################
   # RHEL families
   ##########################################################################


### PR DESCRIPTION
Due to a security issue on Ansible 2.12+, the 'acl' package is necessary
to provision files via become as a non privileged user for another non
privileged user.

https://docs.ansible.com/ansible-core/2.12/user_guide/become.html#risks-of-becoming-an-unprivileged-user

Signed-off-by: Andrew Walsh <awalsh@redhat.com>