### PR TITLE
Fix repo names

### DIFF
--- a/provisioning/group_vars/all/externals.yml
+++ b/provisioning/group_vars/all/externals.yml
@@ -19,7 +19,7 @@ externals:
 
   # Resources provided by the group.
   first-party:
-    rsvpd:
+    bunsen:
       schema: rpm
       host:
         schema: https://

--- a/provisioning/group_vars/all/externals.yml
+++ b/provisioning/group_vars/all/externals.yml
@@ -8,7 +8,7 @@ _repo_prefix: "{{ is_rhel | ternary('epel', ansible_distribution | lower) }}"
 _distro_releasever: "{{ is_fedora | ternary('$releasever', target_distribution_major_number) }}"
 externals:
   # Resources for bunsen functionality.
-  bunsen:
+  bunsensupport:
     python-support:
       schema: rpm
       host:

--- a/provisioning/roles/bunsen/vars/main.yml
+++ b/provisioning/roles/bunsen/vars/main.yml
@@ -6,7 +6,7 @@ install_bunsen_support: false
 ##########################################################################
 # Repositories.
 ##########################################################################
-_bunsen: "{{ externals['bunsen'] }}"
+_bunsensupport: "{{ externals['bunsensupport'] }}"
 bunsen_support_repositories:
   - name: bunsen-python-support
     description: "bunsen python support"
@@ -15,12 +15,12 @@ bunsen_support_repositories:
     gpgcheck: no
     repo_gpgcheck: 0
     sslverify: yes
-    baseurl: "{{ [_bunsen['python-support']['host']['schema'],
-                  _bunsen['python-support']['host']['name'],
-                  _bunsen['python-support']['host']['path']] | join }}"
-    gpgkey: "{{ [_bunsen['python-support']['host']['schema'],
-                 _bunsen['python-support']['host']['name'],
-                 _bunsen['python-support']['host']['keypath']] | join }}"
+    baseurl: "{{ [_bunsensupport['python-support']['host']['schema'],
+                  _bunsensupport['python-support']['host']['name'],
+                  _bunsensupport['python-support']['host']['path']] | join }}"
+    gpgkey: "{{ [_bunsensupport['python-support']['host']['schema'],
+                 _bunsensupport['python-support']['host']['name'],
+                 _bunsensupport['python-support']['host']['keypath']] | join }}"
 
 ##########################################################################
 # Packages.

--- a/provisioning/roles/repos/vars/main.yml
+++ b/provisioning/roles/repos/vars/main.yml
@@ -5,7 +5,7 @@ _repos_selection:
   architecture: "{{ ansible_machine }}"
   environment:
 
-_rsvpd: "{{ externals['first-party']['rsvpd']['host'] }}"
+_bunsen: "{{ externals['first-party']['bunsen']['host'] }}"
 _third_party_common: "{{ externals['third-party']['third-party-common']['host'] }}"
 _repositories:
   # Common to all distributions.
@@ -23,16 +23,16 @@ _repositories:
       repo_gpgcheck: 0
       sslverify: yes
 
-    - name: rsvpd
+    - name: bunsen
       description: "rsvp packages"
       enabled: yes
-      baseurl: "{{ [_rsvpd['schema'],
-                    _rsvpd['name'],
-                    _rsvpd['path']] | join }}"
+      baseurl: "{{ [_bunsen['schema'],
+                    _bunsen['name'],
+                    _bunsen['path']] | join }}"
       gpgcheck: no
-      gpgkey: "{{ [_rsvpd['schema'],
-                   _rsvpd['name'],
-                   _rsvpd['keypath']] | join }}"
+      gpgkey: "{{ [_bunsen['schema'],
+                   _bunsen['name'],
+                   _bunsen['keypath']] | join }}"
       repo_gpgcheck: 0
       sslverify: yes
 


### PR DESCRIPTION
Rename the repositories that are set up to be something more consistent with their application.

bunsen->bunsensupport is intended for installing bunsen support related libraries onto the controller.
rsvpd->bunsen is used for all first-party packages that are needed for bunsen.

Signed-off-by: Andrew Walsh <awalsh@redhat.com>