### PR TITLE
Generalize mount specifications.

### DIFF
--- a/provisioning/group_vars/all/settings.yml
+++ b/provisioning/group_vars/all/settings.yml
@@ -79,6 +79,33 @@ distribution_repo_root_url: "
   {%- endif -%}
   {{ root_url }}"
 
+common_ntp_servers: []
+
+# Provide a default performance farms list to handle the case where the
+# inventory does not have such a group.
+performance_farms: "{{ groups['performance_farms'] | default([]) }}"
+
+# Server definitions.
+# Currently each of these services is tied to the infrastructure role.
+nfs_server: "{{ groups['infrastructure'][0] }}"
+permabuild_server: "{{ groups['infrastructure'][0] }}"
+rsvp_server: "{{ groups['infrastructure'][0] }}"
+
+# Common nfs mount options.  Primarily for use in an environment that has some
+# problematic behavior that should be avoided for all mounts and can be done
+# so via nfs mount optiopns; e.g., IPv6 issues.
+workaround_nfs_mount_opts: proto=tcp
+
+# The permabit build directory location and link.
+permabuild_directory: /permabit/builds/build
+permabuild_directories:
+  - { "server": "{{ nfs_server }}",
+      "src": "{{ permabuild_directory }}",
+      "dest": "{{ permabuild_directory }}" }
+
+permabuild_directories_links:
+  - { dest: /permabit/build,  src: builds/build }
+
 # User accounts to create.
 bunsen_user_account: bunsen
 
@@ -90,10 +117,13 @@ target_user_accounts: "{{ _target_user_accounts | unique | list }}"
 _user_accounts: "{{
   [bunsen_user_account, deploying_user_account] + target_user_accounts }}"
 
-# Where we place local user account's home directories.
-# We do this to avoid, in a vagrant environment, the obscuring of the vagrant
-# user that would result if we just used /home.
-user_homes_local: /home/bunsen-home
+# Source and local directory where we place local user account's home
+# directories. We do this to avoid, in a vagrant environment, the obscuring of
+# the vagrant user that would result if we just used /home.
+user_homes:
+  - { "server": "{{ nfs_server }}",
+      "src": /home/bunsen-home,
+      "dest": /home/bunsen-home }
 
 # We unique the list to cover the possibility of redundancies in account
 # specification then we remove 'root' from the list of users as if we treat it
@@ -101,7 +131,7 @@ user_homes_local: /home/bunsen-home
 user_accounts: "
   {%- set tmp = {} -%}
   {%- for user in (_user_accounts | unique | difference(['root'])) -%}
-    {%- set x = tmp.update({user: {'home' : user_homes_local + '/' + user,
+    {%- set x = tmp.update({user: {'home' : user_homes[0].dest + '/' + user,
                                    'type' : 'local'}}) -%}
   {%- endfor -%}
   {{ tmp }}"
@@ -109,33 +139,11 @@ user_accounts: "
 # Sort the list of usernames for consistent ordering while provisioning.
 user_names_local: "{{ user_accounts.keys() | sort }}"
 
-# Deploying user sshfs mounts to mount.
-deploying_user_sshfs_mounts: "{{ deploying_user_mounts | default([]) }}"
+# User nfs mounts to mount.
+extra_user_nfs_mounts: "{{ user_nfs_mounts | default({}) }}"
 
-# The permabit build directory location and link.
-permabuild_directory: /permabit/builds/build
-permabuild_directories:
-  - "{{ permabuild_directory }}"
-
-permabuild_directories_links:
-  - { dest: /permabit/build,  src: builds/build }
-
-common_ntp_servers: []
-
-# Common nfs mount options.  Primarily for use in an environment that has some
-# problematic behavior that should be avoided for all mounts and can be done
-# so via nfs mount optiopns; e.g., IPv6 issues.
-workaround_nfs_mount_opts: proto=tcp
-
-# Provide a default performance farms list to handle the case where the
-# inventory does not have such a group.
-performance_farms: "{{ groups['performance_farms'] | default([]) }}"
-
-# Server definitions.
-# Currently each of these services is tied to the infrastructure role.
-nfs_server: "{{ groups['infrastructure'][0] }}"
-permabuild_server: "{{ groups['infrastructure'][0] }}"
-rsvp_server: "{{ groups['infrastructure'][0] }}"
+# User sshfs mounts to mount.
+extra_user_sshfs_mounts: "{{ user_sshfs_mounts | default([]) }}"
 
 # Is this machine functioning as a storage server?
 # Default of empty list in determining whether this machine is a storage server

--- a/provisioning/group_vars/infrastructure/settings.yml
+++ b/provisioning/group_vars/infrastructure/settings.yml
@@ -5,14 +5,8 @@ infrastructure: true
 # NFS server variables.
 ###############################################################################
 nfs_directories:
-  - /permabit/not-backed-up
+  - { "server": "{{ nfs_server }}",
+      "src": /permabit/not-backed-up,
+      "dest": /permabit/not-backed-up }
 
-nfs_exports: "{{ nfs_directories + [user_homes_local] }}"
-
-###############################################################################
-# Permabit build server variables.
-###############################################################################
-
-# The permabuild exports.
-permabuild_exports:
-  - "{{ permabuild_directories }}"
+nfs_exports: "{{ nfs_directories + user_homes }}"

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -127,7 +127,7 @@
     # Add ourself as a known host for every user.
     - known_host
 
-- hosts: infrastructure resources farms performance_farms
+- hosts: resources farms performance_farms
   roles:
     # Mount specified sshfs mounts.
     - sshfs_mounts

--- a/provisioning/roles/base/tasks/create_permabuild.yml
+++ b/provisioning/roles/base/tasks/create_permabuild.yml
@@ -82,7 +82,7 @@
 
 - name: Create the permabuild directories.
   file:
-    name: "{{ item }}"
+    name: "{{ item.dest }}"
     mode: 0755
     owner: "root"
     state: directory

--- a/provisioning/roles/environment_facts/tasks/main.yml
+++ b/provisioning/roles/environment_facts/tasks/main.yml
@@ -19,6 +19,10 @@
     set_fact:
       is_farm: "{{ inventory_hostname in groups['farms'] }}"
 
+  - name: Setting resource fact
+    set_fact:
+      is_resource: "{{ inventory_hostname in groups['resources'] }}"
+
   - name: Get controller IPv4 info
     local_action:
       module: setup

--- a/provisioning/roles/nfs_client/tasks/import_nfs.yml
+++ b/provisioning/roles/nfs_client/tasks/import_nfs.yml
@@ -5,7 +5,7 @@
 # exclude directly mounting the NFS server export of the containing directory.
 - include_tasks: "{{ playbook_dir }}/library/mount_nfs.yml"
   vars:
-    name: "{{ item }}"
-    src: "{{ nfs_server }}:{{ item }}"
+    name: "{{ item.dest }}"
+    src: "{{ item.server }}:{{ item.src }}"
   with_items: "
-    {{ hostvars[nfs_server].nfs_exports | difference([user_homes_local]) }}"
+    {{ hostvars[nfs_server].nfs_exports | difference(user_homes) }}"

--- a/provisioning/roles/nfs_client/tasks/import_user_nfs.yml
+++ b/provisioning/roles/nfs_client/tasks/import_user_nfs.yml
@@ -1,0 +1,11 @@
+---
+- block:
+  # Mount the user additional nfs mounts.
+  - include_tasks: "{{ playbook_dir }}/library/mount_nfs.yml"
+    vars:
+      name: "{{ item.dest }}"
+      src: "{{ item.server }}:{{ item.src }}"
+    with_items: "{{ nfs_mounts }}"
+  vars:
+    nfs_mounts: "{{ extra_user_nfs_mounts }}"
+  when: is_farm or is_resource

--- a/provisioning/roles/nfs_client/tasks/main.yml
+++ b/provisioning/roles/nfs_client/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
 - include: import_nfs.yml
+- include: import_user_nfs.yml

--- a/provisioning/roles/nfs_server/tasks/directory_structure.yml
+++ b/provisioning/roles/nfs_server/tasks/directory_structure.yml
@@ -2,7 +2,7 @@
 - block:
   - name: Create shared dirs
     file:
-      path: "{{ item }}"
+      path: "{{ item.src }}"
       state: directory
       mode: 0777
     with_items: "{{ nfs_directories }}"

--- a/provisioning/roles/nfs_server/tasks/export_nfs.yml
+++ b/provisioning/roles/nfs_server/tasks/export_nfs.yml
@@ -2,9 +2,9 @@
 - block:
   - name: Export shared directories
     nfs_exports:
-      name: "{{ item }} Share"
+      name: "{{ item.src }} Share"
       action: add
-      path: "{{ item }}"
+      path: "{{ item.src }}"
       clients: "*"
       read_only: false
       update: true

--- a/provisioning/roles/nfs_server/vars/main.yml
+++ b/provisioning/roles/nfs_server/vars/main.yml
@@ -1,5 +1,8 @@
 # The default directors to create.
 additional_directories:
-  - "/permabit/not-backed-up/tmp"
+  - { "server": "{{ nfs_server }}",
+      "src": /permabit/not-backed-up/tmp,
+      "dest": /permabit/not-backed-up/tmp }
+
 nfs_directories: "{{ hostvars[inventory_hostname].nfs_directories
                      + additional_directories }}"

--- a/provisioning/roles/permabuild_server/tasks/main.yml
+++ b/provisioning/roles/permabuild_server/tasks/main.yml
@@ -3,4 +3,4 @@
     name: nfs_server
   vars:
     nfs_directories: "{{ permabuild_directories }}"
-    nfs_exports: "{{ permabuild_exports }}"
+    nfs_exports: "{{ permabuild_directories }}"

--- a/provisioning/roles/sshfs_mounts/templates/sshfs_mounter
+++ b/provisioning/roles/sshfs_mounts/templates/sshfs_mounter
@@ -11,5 +11,5 @@ try_mount() {
 }
 
 {% for item in sshfs_mounts %}
-try_mount {{ item.mount }} {{ item.source }}
+try_mount {{ item.dest }} {{ item.src }}
 {% endfor %}

--- a/provisioning/roles/sshfs_mounts/vars/main.yml
+++ b/provisioning/roles/sshfs_mounts/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 sshfs_host: "{{ ansible_controller_ip }}"
-sshfs_mounts: "{{ deploying_user_sshfs_mounts }}"
+sshfs_mounts: "{{ extra_user_sshfs_mounts }}"
 sshfs_user: "{{ deploying_user_account | default('') }}"

--- a/provisioning/roles/user_accounts/tasks/user_accounts.yml
+++ b/provisioning/roles/user_accounts/tasks/user_accounts.yml
@@ -9,7 +9,7 @@
   # Add all accounts locally.
   - name: Create local user homes directory
     file:
-      dest: "{{ user_homes_local }}"
+      dest: "{{ user_homes[0].src }}"
       state: directory
     when: inventory_hostname == nfs_server
     become: yes
@@ -64,8 +64,8 @@
     - name: Add /etc/auto.bunsen-home to /etc/auto.master
       lineinfile:
         path: /etc/auto.master
-        regexp: '^{{ user_homes_local }}[ \t]+/etc/auto\.bunsen-home'
-        line: "{{ user_homes_local }} /etc/auto.bunsen-home"
+        regexp: '^{{ user_homes[0].dest }}[ \t]+/etc/auto\.bunsen-home'
+        line: "{{ user_homes[0].dest }} /etc/auto.bunsen-home"
       become: yes
 
     - name: Start autofs

--- a/provisioning/roles/user_accounts/templates/auto.bunsen-home
+++ b/provisioning/roles/user_accounts/templates/auto.bunsen-home
@@ -6,6 +6,6 @@ case "$1" in
     .* ) exit 1 ;;
 esac
 
-echo -fstype=nfs,rw,soft,tcp {{ nfs_server }}:{{ user_homes_local }}/$1
+echo -fstype=nfs,rw,soft,tcp {{ user_homes[0].server }}:{{ user_homes[0].src }}/$1
 
 exit 0


### PR DESCRIPTION
This applies to both nfs and sshfs mounts.
Makes a mount specification a dictionary with keys 'server', 'src' and 'dest'.
'server' is the name/ip of the server.
'src' is the server-side path of the exported source.
'dest' is the client-side path where to mount the export.
Operationally the specifications are organized in a list.

Includes the new task import_user_nfs.yml in the role nfs_client.  This task creates the client-side mount point and mounts the export from the server.  These mounts are specified via the optional ansible extra variable 'user_nfs_mounts' which is a list of mount specifications as described previously.

Signed-off-by: Joe Shimkus <jshimkus@redhat.com>