### PR TITLE
Add kernel-abi-whitelists package for installation in RHEL7

### DIFF
--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -59,6 +59,7 @@ _farm_packages:
   # Common to all RHEL 7 family starting with RHEL 7.5 family.
   - (CentOS|RedHat)7\.([1-9][0-9]+|[5-9]):
     - numpy
+    - kernel-abi-whitelists
 
   # Common to all RHEL families starting with RHEL 8.0 family.
   - (CentOS|RedHat)(?![1-7]\.[0-9]+)[1-9][0-9]*\.[0-9]+:

--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -58,9 +58,9 @@ _farm_packages:
 
   # Common to all RHEL 7 family starting with RHEL 7.5 family.
   - (CentOS|RedHat)7\.([1-9][0-9]+|[5-9]):
-    - numpy
     - kernel-abi-whitelists
-
+    - numpy
+ 
   # Common to all RHEL families starting with RHEL 8.0 family.
   - (CentOS|RedHat)(?![1-7]\.[0-9]+)[1-9][0-9]*\.[0-9]+:
     - dosfstools


### PR DESCRIPTION
because it is needed for VDO_Upgrade_Tests suite.