### PR TITLE
Provisioning modifications for multi arch testing.

### DIFF
--- a/provisioning/roles/base/vars/main.yml
+++ b/provisioning/roles/base/vars/main.yml
@@ -197,8 +197,8 @@ _perl_libraries:
     - aarch64:
     - ppc64le:
     - s390x:
-      # Common to all RHEL families starting with RHEL 8.0 family.
-      - (CentOS|RedHat)(?![1-7]\.[0-9]+)[1-9][0-9]*\.[0-9]+:
+      # Common to all RHEL 8 families through RHEL 8.5 family.
+      - (CentOS|RedHat)8\.([1-9][0-9]+|[0-5]):
         # Clone (required by PPI) version 0.42 and later has a new dependency
         # on B::COW (which is at version 0.001, so there's nothing to roll back
         # to there) which doesn't install on RHEL8 for S390X.  So, we specify a

--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -26,6 +26,7 @@ _farm_packages:
     - perf
     - permatest
     - perl-Permabit-checkServer
+    - rpm-build
     - rsyslog
     - strace
     - sysstat
@@ -65,6 +66,9 @@ _farm_packages:
   - (CentOS|RedHat)(?![1-7]\.[0-9]+)[1-9][0-9]*\.[0-9]+:
     - dosfstools
     - python3-numpy
+    - device-mapper-devel
+    - device-mapper-eveent-devel
+    - valgrind-devel
 
   # Common to all RHEL 7 and 8 family.
   - (CentOS|RedHat)(7|8)\.[0-9]+:


### PR DESCRIPTION
Modify the regex for installing Clone on RHEL8 s390x hosts, as it is
not necessary for RHEL 8.6. For RHEL 8.6 S390X machines, Clone is
not included and cannot be found by cpan, thus causing provisioning
to fail.

Add rpm-build to the list of common packages required for all farms.
Add device-mapper-devel, device-mapper-event-devel and valgrind-devel
to the list of packages required for RHEL8 family farms.
These packages are needed by multi arch upgrade tests in order to
rebuild the kmod-kvdo and vdo modules.

Signed-off-by: Susan LeGendre-McGhee <slegendr@redhat.com>