### PR TITLE
Install kernel-abi-stablelists on RHEL8 and 9 farms.

### DIFF
--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -57,9 +57,12 @@ _farm_packages:
   - Fedora([1-9][0-9]{2,}|29|[3-9][0-9]):
     - numpy
 
+  # Common to all RHEL 7 family and RHEL 8 through RHEL 8.3 family.
+  - (CentOS|RedHat)((8\.[0-3]$)|(7\.([1-9][0-9]+|[0-9]))):
+    - kernel-abi-whitelists
+
   # Common to all RHEL 7 family starting with RHEL 7.5 family.
   - (CentOS|RedHat)7\.([1-9][0-9]+|[5-9]):
-    - kernel-abi-whitelists
     - numpy
  
   # Common to all RHEL families starting with RHEL 8.0 family.
@@ -69,6 +72,10 @@ _farm_packages:
     - device-mapper-devel
     - device-mapper-event-devel
     - valgrind-devel
+
+  # Common to all RHEL 8 family starting with RHEL 8.4 and all RHEL 9 family.
+  - (CentOS|RedHat)((8\.([1-9][0-9]+|[4-9]))|(9\.[0-9]+)):
+    - kernel-abi-stablelists
 
   # Common to all RHEL 7 and 8 family.
   - (CentOS|RedHat)(7|8)\.[0-9]+:


### PR DESCRIPTION
Add a regex for installing kernel-abi-whitelists that encompasses RHEL 7 through RHEL 8.3.

Remove kernel-abi-whitelists from the regex for RHEL 7 families starting with RHEL 7.5.

Add a regex for installing kernel-abi-stablelists for RHEL 8.4 and beyond, as it replaces kernel-abi-whitelists.

Signed-off-by: Susan LeGendre-McGhee <slegendr@redhat.com>