### PR TITLE
Switch and Save.

### DIFF
--- a/provisioning/roles/base/tasks/local_resolution_tweaks.yml
+++ b/provisioning/roles/base/tasks/local_resolution_tweaks.yml
@@ -1,0 +1,12 @@
+---
+# Removes a controversial "give up" setting in nsswitch that shows up on newer
+# distros.
+#XXX: This is not getting restricted by distro, but currently only affects
+#     Fedora35 and up, but that doesn't mean it won't show up in a later
+#     release of something else.
+- name: Remove [!UNAVAIL=return] from nsswitch.conf
+  replace:
+    path: /etc/nsswitch.conf
+    regexp: '^(hosts:.*)\[!UNAVAIL=return\](.*)'
+    replace: '\1 \2'
+  become: yes

--- a/provisioning/roles/base/tasks/main.yml
+++ b/provisioning/roles/base/tasks/main.yml
@@ -54,3 +54,6 @@
 - include: search_path.yml
 - include: ssh.yml
   when: enable_proxy_vagrant_ssh_config | bool
+
+# Update local name resolution configurations
+- include_tasks: local_resolution_tweaks.yml

--- a/provisioning/roles/farm/tasks/storage-loop.yml
+++ b/provisioning/roles/farm/tasks/storage-loop.yml
@@ -3,9 +3,9 @@
 # Set up a big file (sparse is okay) and a loop device to act as a volume group
 # for VDO test storage.
 
-# Inputs: mount (relative to /), path (relative to mount),
-#         min_size, max_size, disk_var.
-# Sets facts, registers: {{disk_var}}, losetup_result.
+# Inputs: mount (relative to / or, as a special case, '/'),
+#         path (relative to mount), min_size, max_size, disk_var, volume_group.
+# Sets facts, registers: {{disk_var}}, {{volume_group}} and losetup_result.
 
 - name: Checking free space
   setup:
@@ -68,6 +68,12 @@
     set_fact:
       "{{ disk_var }}": "{{ losetup_result.stdout.split(':')[0] }}"
 
+  - name: Picking scratch volume group name
+    set_fact:
+      "{{ volume_group }}": "{{ ansible_default_ipv4.macaddress.split(':')
+                                | join }}"
+
   vars:
-    mount_path: "{{ ('', mount) | join('/') }}"
+    mount_path: "{{ (mount == '/')
+                  | ternary(mount, ('', mount) | join('/')) }}"
     destination_path: "{{ (mount_path, path) | join('/') }}"

--- a/provisioning/roles/farm/tasks/storage.yml
+++ b/provisioning/roles/farm/tasks/storage.yml
@@ -48,12 +48,9 @@
             path: big_file
             min_size: "{{ required }}"
             max_size: "{{ (vdo_scratch_max_gb * 1024 * 1024) | int }}"
-            # test_disk is set by storage-loop.yml.
+            # test_disk and scratch_vg are set by storage-loop.yml.
             disk_var: test_disk
-
-        - name: Picking scratch volume group name
-          set_fact:
-            scratch_vg: "{{ ansible_default_ipv4.macaddress.split(':') | join }}"
+            volume_group: scratch_vg
       when: (scratch_vg is not defined) and ('/home' in mount_points)
 
     - block:
@@ -66,6 +63,21 @@
       when: (scratch_vg is not defined)
               and (ansible_lvm is defined)
               and ('root' in ansible_lvm.lvs.keys())
+
+    - block:
+        # scratch_vg not defined.
+        # Create a big file on / and use it via a loop device as a
+        # physical volume.
+        - include_tasks: storage-loop.yml
+          vars:
+            mount: /
+            path: big_file
+            min_size: "{{ required }}"
+            max_size: "{{ (vdo_scratch_max_gb * 1024 * 1024) | int }}"
+            # test_disk and scratch_vg are set by storage-loop.yml.
+            disk_var: test_disk
+            volume_group: scratch_vg
+      when: (scratch_vg is not defined)
     when: (not use_storage_server) or (inventory_hostname not in storage_clients)
 
   # System with an external storage server specified: Use it.


### PR DESCRIPTION
Incorporate tweak to nsswitch.conf to avoid early termination on hostname resolution.

Add fallback to loop device on root for farm test storage if no other storage is available and the root partition is large enough.