### PR TITLE
Assign user ids.

### DIFF
--- a/provisioning/group_vars/all/settings.yml
+++ b/provisioning/group_vars/all/settings.yml
@@ -125,19 +125,27 @@ user_homes:
       "src": /home/bunsen-home,
       "dest": /home/bunsen-home }
 
+# Different distributions may have varyinng user ids already in use.  This is a
+# problem in heterogeneous environments as we require that user ids are the
+# same on all systems.  To lessen the likelihood of this problem we start local
+# user uids at a specific value far removed from the default minimum.
+local_user_start_uid: 3500
+
 # We unique the list to cover the possibility of redundancies in account
 # specification then we remove 'root' from the list of users as if we treat it
 # as we do any other account we create it messes up provisioning.
+# As we are assigning uids to local users we sort the user accounts here to
+# establish identical uids across systems.
 user_accounts: "
   {%- set tmp = {} -%}
-  {%- for user in (_user_accounts | unique | difference(['root'])) -%}
+  {%- set local_uid = namespace(value=local_user_start_uid) -%}
+  {%- for user in (_user_accounts | unique | difference(['root']) | sort) -%}
     {%- set x = tmp.update({user: {'home' : user_homes[0].dest + '/' + user,
+                                   'uid'  : local_uid.value,
                                    'type' : 'local'}}) -%}
+    {%- set local_uid.value = local_uid.value + 1 -%}
   {%- endfor -%}
   {{ tmp }}"
-
-# Sort the list of usernames for consistent ordering while provisioning.
-user_names_local: "{{ user_accounts.keys() | sort }}"
 
 # User nfs mounts to mount.
 extra_user_nfs_mounts: "{{ user_nfs_mounts | default({}) }}"

--- a/provisioning/roles/user_accounts/tasks/user_accounts.yml
+++ b/provisioning/roles/user_accounts/tasks/user_accounts.yml
@@ -26,17 +26,16 @@
     register: os_result
 
   - block:
-    # These two blocks must create the same list of accounts, in the same
-    # order, in order to ensure matching UID allocations!
     - name: Add local user accounts to infrastructure system
       user:
         name: "{{ item }}"
         home: "{{ user_accounts[item].home }}"
+        uid: "{{ user_accounts[item].uid }}"
         create_home: True
         password: "{{ user_password }}"
         group: staff
         append: yes
-      with_items: "{{ user_names_local }}"
+      with_items: "{{ user_accounts.keys() }}"
       when: inventory_hostname == nfs_server
       become: yes
 
@@ -45,11 +44,12 @@
       user:
         name: "{{ item }}"
         home: "{{ user_accounts[item].home }}"
+        uid: "{{ user_accounts[item].uid }}"
         create_home: False
         password: "{{ user_password }}"
         group: staff
         append: yes
-      with_items: "{{ user_names_local }}"
+      with_items: "{{ user_accounts.keys() }}"
       when: inventory_hostname != nfs_server
       become: yes
 
@@ -87,5 +87,5 @@
       mode: 0600
       owner: root
       group: root
-    with_items: "{{ user_names_local }}"
+    with_items: "{{ user_accounts.keys() }}"
     become: yes


### PR DESCRIPTION
Assign uids to user accounts starting far removed from the default minimum. This lessens the likelihood of uid variance across disparate distributions.