### PR TITLE
Remove "warn" argument from tasks.

### DIFF
--- a/provisioning/library/get_perl_modules.yml
+++ b/provisioning/library/get_perl_modules.yml
@@ -34,8 +34,6 @@
                  --disablerepo '*-debuginfo' \
                  {{ extra_repos | trim }} \
                  perl- 2>/dev/null
-    args:
-      warn: False
     become: yes
     changed_when: False
     register: dnf

--- a/provisioning/roles/rebooting_tasks/tasks/configure_farm.yml
+++ b/provisioning/roles/rebooting_tasks/tasks/configure_farm.yml
@@ -22,8 +22,6 @@
     - name: Edit /etc/default/grub to set crashkernel size
       shell: |
         sed -i -e '/CMDLINE_LINUX/{/crashkernel=[0-9]/!{s/crashkernel=auto//;s/="/="crashkernel=300M /;}}' /etc/default/grub
-      args:
-        warn: False
       become: yes
     - name: Rebuild grub configuration
       command: "grub2-mkconfig -o {{ item.path }}"

--- a/provisioning/roles/rebooting_tasks/tasks/main.yml
+++ b/provisioning/roles/rebooting_tasks/tasks/main.yml
@@ -22,8 +22,6 @@
 
 - name: Check for older packages to be uninstalled
   command: dnf repoquery --installonly --latest-limit=-1 -q
-  args:
-    warn: False
   # Really, if packaging system is DNF vs Yum...
   when: ansible_pkg_mgr == "dnf"
   changed_when: False
@@ -31,7 +29,5 @@
 
 - name: Remove older kernels
   command: "dnf remove --assumeyes {{ repoquery.stdout }}"
-  args:
-    warn: False
   become: yes
   when: (ansible_pkg_mgr == "dnf") and (repoquery.stdout != "")

--- a/provisioning/roles/repartition_home/tasks/repartition.yml
+++ b/provisioning/roles/repartition_home/tasks/repartition.yml
@@ -20,8 +20,6 @@
 - name: Copy /home to /home2
   # --acls --xattrs ?
   shell: "mkdir /home2 && rsync -aHS /home/. /home2/. && sync"
-  args:
-    warn: False
   become: yes
 
 - name: Unmount /home
@@ -45,8 +43,6 @@
 
 - name: Move /home2 to /home
   shell: "rm -rf /home && mv -f /home2 /home"
-  args:
-    warn: False
   become: yes
 
 - name: Retrieve LVM configuration

--- a/provisioning/roles/storage_server/tasks/repartition.yml
+++ b/provisioning/roles/storage_server/tasks/repartition.yml
@@ -27,8 +27,6 @@
    - name: Copy /home to /home2
      # --acls --xattrs ?
      shell: "mkdir /home2 && rsync -aHS /home/. /home2/."
-     args:
-       warn: False
      when: must_relocate_home | bool
      become: yes
 
@@ -55,8 +53,6 @@
 
    - name: Move /home2 to /home
      shell: "rm -rf /home && mv -f /home2 /home"
-     args:
-       warn: False
      when: must_relocate_home | bool
      become: yes
 


### PR DESCRIPTION
No longer supported by current ansible which also no longer "warns" to use ansible modules for the operations (the avoidance of which is why "warn" was used in the first place).