### PR TITLE
Remove "warn" argument from tasks.

### DIFF
--- a/provisioning/library/get_perl_modules.yml
+++ b/provisioning/library/get_perl_modules.yml
@@ -34,8 +34,6 @@
                  --disablerepo '*-debuginfo' \
                  {{ extra_repos | trim }} \
                  perl- 2>/dev/null
-    args:
-      warn: False
     become: yes
     changed_when: False
     register: dnf

--- a/provisioning/library/restart_system.yml
+++ b/provisioning/library/restart_system.yml
@@ -4,15 +4,6 @@
 # places, and we may need to tweak this a bit to get it to work right,
 # since it involves losing our connection to the target machine etc.
 
-# Note that Ansible 2.7 has a "reboot" module, but Fedora 28 ships
-# with Ansible 2.6.5. (CSB is RHEL 7.4 with 2.4.2.0.) Perhaps once we
-# can assume 2.7 we can use that and drop this file.
-
-# Some recommended advice from the net uses "sleep 5 && reboot" with
-# "async: 1" and "poll: 0" to trigger the reboot, which worked with
-# RHEL 7.5, but doesn't seem to work with Fedora 28. We don't know why
-# yet.
-
 - block:
 
   # The sequence used in the Red Hat "rhts_reboot" script is to use
@@ -80,16 +71,9 @@
   # extra text after the JSON payload.
 
   - name: Restart system
-    command: "shutdown --no-wall -r +1"
+    reboot:
+      connect_timeout: 30
+      pre_reboot_delay: 90
+      post_reboot_delay: 90
+    retries: 2
     become: yes
-
-  # After 60 seconds, the above command will *start* the reboot
-  # sequence, which involves cleanly shutting down system services. On
-  # a simple farm configuration, it's not likely to take long, but
-  # we're gambling on that. Better would be to wait for the machine to
-  # be reachable *and* for its reported uptime to indicate that it has
-  # rebooted.
-
-  - name: Wait for system to become available
-    wait_for_connection:
-      delay: 90

--- a/provisioning/roles/rebooting_tasks/tasks/configure_farm.yml
+++ b/provisioning/roles/rebooting_tasks/tasks/configure_farm.yml
@@ -22,8 +22,6 @@
     - name: Edit /etc/default/grub to set crashkernel size
       shell: |
         sed -i -e '/CMDLINE_LINUX/{/crashkernel=[0-9]/!{s/crashkernel=auto//;s/="/="crashkernel=300M /;}}' /etc/default/grub
-      args:
-        warn: False
       become: yes
     - name: Rebuild grub configuration
       command: "grub2-mkconfig -o {{ item.path }}"

--- a/provisioning/roles/rebooting_tasks/tasks/main.yml
+++ b/provisioning/roles/rebooting_tasks/tasks/main.yml
@@ -22,8 +22,6 @@
 
 - name: Check for older packages to be uninstalled
   command: dnf repoquery --installonly --latest-limit=-1 -q
-  args:
-    warn: False
   # Really, if packaging system is DNF vs Yum...
   when: ansible_pkg_mgr == "dnf"
   changed_when: False
@@ -31,7 +29,5 @@
 
 - name: Remove older kernels
   command: "dnf remove --assumeyes {{ repoquery.stdout }}"
-  args:
-    warn: False
   become: yes
   when: (ansible_pkg_mgr == "dnf") and (repoquery.stdout != "")

--- a/provisioning/roles/repartition_home/tasks/repartition.yml
+++ b/provisioning/roles/repartition_home/tasks/repartition.yml
@@ -20,8 +20,6 @@
 - name: Copy /home to /home2
   # --acls --xattrs ?
   shell: "mkdir /home2 && rsync -aHS /home/. /home2/. && sync"
-  args:
-    warn: False
   become: yes
 
 - name: Unmount /home
@@ -45,8 +43,6 @@
 
 - name: Move /home2 to /home
   shell: "rm -rf /home && mv -f /home2 /home"
-  args:
-    warn: False
   become: yes
 
 - name: Retrieve LVM configuration

--- a/provisioning/roles/storage_server/tasks/repartition.yml
+++ b/provisioning/roles/storage_server/tasks/repartition.yml
@@ -27,8 +27,6 @@
    - name: Copy /home to /home2
      # --acls --xattrs ?
      shell: "mkdir /home2 && rsync -aHS /home/. /home2/."
-     args:
-       warn: False
      when: must_relocate_home | bool
      become: yes
 
@@ -55,8 +53,6 @@
 
    - name: Move /home2 to /home
      shell: "rm -rf /home && mv -f /home2 /home"
-     args:
-       warn: False
      when: must_relocate_home | bool
      become: yes
 


### PR DESCRIPTION
No longer supported by current ansible which also no longer "warns" to use ansible modules for the operations (the avoidance of which is why "warn" was used in the first place).