### PR TITLE
Install same packages for aarch64 as x86_64.

### DIFF
--- a/provisioning/roles/rebooting_tasks/vars/main.yml
+++ b/provisioning/roles/rebooting_tasks/vars/main.yml
@@ -30,11 +30,20 @@ _kernel_packages:
   - architecture:
     - aarch64:
       - common:
+        - kernel-debug
+        - kernel-debug-devel
         - kernel-tools-libs
+
+      # Common to all Fedora starting with Fedora28.
+      - Fedora([1-9][0-9]{2,}|2[8-9]|[3-9][0-9]):
+        - kernel-debug-core
+
     - ppc64le:
       - common:
         - kernel-tools-libs
+
     - s390x:
+
     - x86_64:
       - common:
         - kernel-debug


### PR DESCRIPTION
Makes kdump service available on machine.