### PR TITLE
Make certain loop device-derived VGs and LVs are active on cold boot.

### DIFF
--- a/provisioning/roles/farm/tasks/storage-loop.yml
+++ b/provisioning/roles/farm/tasks/storage-loop.yml
@@ -75,5 +75,9 @@
 
   vars:
     mount_path: "{{ (mount == '/')
-                  | ternary(mount, ('', mount) | join('/')) }}"
-    destination_path: "{{ (mount_path, path) | join('/') }}"
+                      | ternary(mount, ('', mount) | join('/')) }}"
+    destination_path: "{{ ((mount_path == '/') | ternary('', mount_path),
+                            path) | join('/') }}"
+    loop_after: "{{ (mount | replace('/', '-')) ~ '.mount' }}"
+    loop_before: "u1.mount"
+    loop_requires: "{{ loop_after }}"

--- a/provisioning/roles/farm/templates/loop-setup.service
+++ b/provisioning/roles/farm/templates/loop-setup.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Activate VDO scratch loop device
-Requires={{ mount }}.mount
-Before=u1.mount
-After={{ mount }}.mount
+Requires={{ loop_requires }}
+Before={{ loop_before }}
+After={{ loop_after }}
 #Wants=...
 
 [Service]
 ExecStart=/sbin/losetup -f {{ destination_path }}
+ExecStart=udevadm trigger
 ExecStop=/sbin/losetup -D
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
As a last resort bunsen provisioning will use a loop device to provide storage for /u1 and the test scratch device.  In the case of a cold boot the current implementation leaves the VG and LVs created from the loop device inactive.  This change adds a 'udevadm trigger' as part of the systemd service starting the loop device which causes the VG and LVs to be recognized and activated.