### PR TITLE
Update setting python alternative in bunsen.

### DIFF
--- a/provisioning/library/set_python_alternative.yml
+++ b/provisioning/library/set_python_alternative.yml
@@ -1,15 +1,24 @@
 ---
 # Arguments:
 #   alternative: string; the python alternative to use
-#   omit_link:   boolean; whether to omit the link value
 - name: Set the preferred Python version
   alternatives:
+    link: "{{ (is_rhel8_family | bool)
+                | ternary('/usr/bin/unversioned-python',
+                          '/etc/alternatives/python') }}"
     name: python
-    link: "{{ (omit_link | bool) | ternary(omit, '/usr/bin/python') }}"
     path: /usr/bin/{{ item }}
     priority: 1000
   # The one-item loop here is just so that the logged message will show the
   # chosen alternative for each host.
   with_items:
     - "{{ alternative }}"
-  become: yes
+
+# Link /usr/bin/python link to /etc/alternatives/python.
+# We only need to do this in RHEL8.
+- name: Set /usr/bin/python link for RHEL8
+  ansible.builtin.file:
+    src: /etc/alternatives/python
+    dest: /usr/bin/python
+    state: link
+  when: is_rhel8_family | bool

--- a/provisioning/roles/base/tasks/alternatives.yml
+++ b/provisioning/roles/base/tasks/alternatives.yml
@@ -2,4 +2,3 @@
 - include_tasks: "{{ playbook_dir }}/library/set_python_alternative.yml"
   vars:
     alternative: "{{ python_alternative }}"
-    omit_link: "{{ is_rhel8_family }}"

--- a/provisioning/roles/storage_server/tasks/main.yml
+++ b/provisioning/roles/storage_server/tasks/main.yml
@@ -3,7 +3,6 @@
 - include_tasks: "{{ playbook_dir }}/library/set_python_alternative.yml"
   vars:
     alternative: "{{ python_alternative }}"
-    omit_link: no
 
 - include_tasks: repartition.yml
 - include_tasks: packages.yml


### PR DESCRIPTION
Ansible no longer allows omission of the 'link' parameter as part of the alternatives module.  This change modifies the setting of the python alternative to use the 'link' parameter for all distributions and to link, for RHEL8 only, /usr/bin/python to /etc/alternatives/python.