### PR TITLE
Fix bunsen identification of machine as a kvm guest.

### DIFF
--- a/provisioning/roles/farm/tasks/storage.yml
+++ b/provisioning/roles/farm/tasks/storage.yml
@@ -31,7 +31,17 @@
           test_disk: "/dev/{{aux_disk}}"
 
       vars:
-        aux_disk: "{%- if ansible_virtualization_type == 'kvm' -%}
+        # Attempt to use more modern ansible variable which provides ability to
+        # distinguish the possibilities of nested virtualization. If it's not
+        # available infer the machine is a virtualization guest if its
+        # virtualization role is not 'host'.
+        guest_tech: "{{ ansible_virtualization_tech_guest
+                        | default(
+                            (ansible_virtualization_type != 'kvm')
+                            | ternary([],
+                                      (ansible_virtualization_role == 'host')
+                                      | ternary([], ['kvm']))) }}"
+        aux_disk: "{%- if 'kvm' in guest_tech -%}
                      vdb
                    {%- else -%}
                      sdb


### PR DESCRIPTION
The check that the machine's virtualization type is kvm is not sufficient.  A machine can have a virtualization type of kvm but not be a guest, rather a host providing virtualization.  In the case of nested virtualization the machine can be both.

This change uses relatively new ansible variables, if available, that disambiguate a machine's role as guest and/or host.  If these new variables are not available the change makes the determination the machine is a guest by its role not being host.