### PR TITLE
Adapt to ansible changes re ansible_lvm.

### DIFF
--- a/provisioning/roles/farm/tasks/storage.yml
+++ b/provisioning/roles/farm/tasks/storage.yml
@@ -71,7 +71,7 @@
             scratch_vg: "{{ ansible_lvm.lvs['root'].vg }}"
             test_disk: ""
       when: (scratch_vg is not defined)
-              and (ansible_lvm is defined)
+              and ((ansible_lvm is defined) and (ansible_lvm is mapping))
               and ('root' in ansible_lvm.lvs.keys())
 
     - block:
@@ -238,7 +238,8 @@
     vdo_scratch_max_gb: 150
     existing_lvs: "
       {%- set tmp = {} -%}
-      {%- set lvs = (ansible_lvm is defined) | ternary(ansible_lvm.lvs, {}) -%}
+      {%- set lvs = ((ansible_lvm is defined) and (ansible_lvm is mapping))
+                    | ternary(ansible_lvm.lvs, {}) -%}
       {%- for lv in lvs -%}
         {%- set x = tmp.update({ lvs[lv].vg+'/'+lv : 1 }) -%}
       {%- endfor -%}

--- a/provisioning/roles/repartition_home/vars/main.yml
+++ b/provisioning/roles/repartition_home/vars/main.yml
@@ -1,11 +1,11 @@
 ---
 #
-existing_lvs: "{%- if ansible_lvm is defined -%}
+existing_lvs: "{%- if ((ansible_lvm is defined) and (ansible_lvm is mapping)) -%}
                  {{ ansible_lvm.lvs.keys() | list }}
                {%- else -%}
                  {{ [] }}
                {%- endif -%}"
-existing_vgs: "{%- if ansible_lvm is defined -%}
+existing_vgs: "{%- if ((ansible_lvm is defined) and (ansible_lvm is mapping)) -%}
                  {{ ansible_lvm.vgs.keys() | list }}
                {%- else -%}
                  {{ [] }}


### PR DESCRIPTION
It was the case that ansible_lvm was not defined if there were no lvm-related entities on a system.  More recent ansible versions are returning ansible_lvm regardless with the twist that when there are no lvm-related entities it is a string ("N/A") rather than a mapping.

This change addresses the change by continuing to check if ansible_lvm is defined with an additional check that it is a mapping.