### PR TITLE
Ensure lsscsi is installed on Fedora hosts.

### DIFF
--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -57,6 +57,10 @@ _farm_packages:
   - Fedora([1-9][0-9]{2,}|29|[3-9][0-9]):
     - numpy
 
+  # Common to all Fedora starting with Fedora37.
+  - Fedora([1-9][0-9]{2,}|3[7-9]|[4-9][0-9]):
+    - lsscsi
+
   # Common to all RHEL 7 family and RHEL 8 through RHEL 8.3 family.
   - (CentOS|RedHat)((8\.[0-3]$)|(7\.([1-9][0-9]+|[0-9]))):
     - kernel-abi-whitelists


### PR DESCRIPTION
Add an instruction to install lsscsi on Fedora37+ hosts. When missing, it causes VDO perl tests to fail when trying to activate an ISCSI device after migration.