### PR TITLE
Default include ansible controller as NTP server.

### DIFF
--- a/provisioning/group_vars/all/settings.yml
+++ b/provisioning/group_vars/all/settings.yml
@@ -79,8 +79,6 @@ distribution_repo_root_url: "
   {%- endif -%}
   {{ root_url }}"
 
-common_ntp_servers: []
-
 # Machine type groups.
 # Farms, pfarms and performance farms.
 farms: "{{ groups['farms'] | default([]) }}"
@@ -174,6 +172,12 @@ user_accounts: "
     {%- set local_uid.value = local_uid.value + 1 -%}
   {%- endfor -%}
   {{ tmp }}"
+
+# User ntp servers to use.
+extra_user_ntp_servers: "{{ (user_ntp_servers | default([])) | unique }}"
+
+# The total set of ntp servers.
+common_ntp_servers: "{{ [] + extra_user_ntp_servers }}"
 
 # User nfs mounts to mount.
 extra_user_nfs_mounts: "{{ user_nfs_mounts | default({}) }}"

--- a/provisioning/roles/environment_facts/tasks/main.yml
+++ b/provisioning/roles/environment_facts/tasks/main.yml
@@ -26,6 +26,11 @@
     set_fact:
       ansible_controller_ip: "{{ hostvars['localhost']['ansible_default_ipv4']['address'] }}"
 
+  - name: Include ansible controller as an NTP server
+    set_fact:
+      common_ntp_servers: '{{ (common_ntp_servers + [ansible_controller_ip]) | unique }}'
+    when: (extra_user_ntp_servers | length) == 0
+
   - name: Setting default alternative package facts
     # If the machine is being used as the storage server it needs to use
     # python3 as its default python as the storage software used for iSCSI


### PR DESCRIPTION
If the user does not specify one or more NTP servers to use include the ansible controller's IPv4 address as such.