### PR TITLE
Added new packages that farms now require

### DIFF
--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -15,6 +15,7 @@ _farm_packages:
     - blktrace
     - crash
     - cryptsetup
+    - device-mapper-event-devel
     - dwarves
     - elfutils
     - gdb
@@ -22,10 +23,11 @@ _farm_packages:
     - kernel-debuginfo
     - kexec-tools
     - libaio
+    - libuuid-devel
     - lvm2
     - perf
-    - permatest
     - perl-Permabit-checkServer
+    - permatest
     - rpm-build
     - rsyslog
     - strace
@@ -34,6 +36,7 @@ _farm_packages:
     - systemtap-devel
     - targetcli
     - valgrind
+    - valgrind-devel
     - xfsdump
     - yum-plugin-auto-update-debug-info
 
@@ -64,7 +67,7 @@ _farm_packages:
   # Common to all RHEL 7 family starting with RHEL 7.5 family.
   - (CentOS|RedHat)7\.([1-9][0-9]+|[5-9]):
     - numpy
- 
+
   # Common to all RHEL families starting with RHEL 8.0 family.
   - (CentOS|RedHat)(?![1-7]\.[0-9]+)[1-9][0-9]*\.[0-9]+:
     - dosfstools


### PR DESCRIPTION
The build process has been updated to leverage SRPMs a bit more, which now requires farms to do some building on them.  In order to accomplish that, they need some additional packages.