### PR TITLE
Copy journald.conf file from /usr/lib/systemd

### DIFF
--- a/provisioning/roles/base/tasks/persistent_journal.yml
+++ b/provisioning/roles/base/tasks/persistent_journal.yml
@@ -1,4 +1,17 @@
 ---
+- name: Check lib journald.conf
+  stat:
+    path: /usr/lib/systemd/journald.conf
+  register: has_lib_journald_conf
+
+- name: Copy journald.conf
+  ansible.builtin.copy:
+    src: /usr/lib/systemd/journald.conf
+    dest: /etc/systemd/journald.conf
+    remote_src: yes
+    force: false
+  when: has_lib_journald_conf.stat.exists
+
 - name: Update journald.conf
   lineinfile:
     path: /etc/systemd/journald.conf


### PR DESCRIPTION
Starting from Fedora 40, journald.conf file is no longer in /etc/systemd by default. Since bunsen is expecting journald.conf to be in /etc/systemd, we copy it from /usr/lib/systemd. The /usr/lib/systemd/journald.conf file does not exist in previous Fedora and RHEL releases, therefore we need to test it first before we copy it.