### PR TITLE
Add become: yes to copy

### DIFF
--- a/provisioning/roles/base/tasks/persistent_journal.yml
+++ b/provisioning/roles/base/tasks/persistent_journal.yml
@@ -10,6 +10,7 @@
     dest: /etc/systemd/journald.conf
     remote_src: yes
     force: false
+  become: yes
   when: has_lib_journald_conf.stat.exists
 
 - name: Update journald.conf


### PR DESCRIPTION
/etc/systemd is a system write protect directory. We need to add become: yes.