### PR TITLE
Disable kdump service

### DIFF
--- a/provisioning/roles/farm/tasks/config.yml
+++ b/provisioning/roles/farm/tasks/config.yml
@@ -1,17 +1,6 @@
 ---
 - include_tasks: release_config_dir.yml
 
-# Do this after the reboot that ensures that crashkernel memory has been
-# reserved.
-- name: Enabling kdump service
-  systemd:
-    name: kdump.service
-    state: started
-    enabled: True
-  # See above re: zipl boot loader.
-  when: is_fedora and (not is_arch_s390x)
-  become: yes
-
 - name: Enable use of /proc/sysrq-trigger
   sysctl:
     name: kernel.sysrq


### PR DESCRIPTION
Disable kdump in vdo-vpt configuration since it is not necessary.