### PR TITLE
Add Test::Unit and Proc::Simple to common perl packages

### DIFF
--- a/provisioning/roles/base/vars/main.yml
+++ b/provisioning/roles/base/vars/main.yml
@@ -267,12 +267,14 @@ _perl_libraries:
     - Perl::Critic::More
     - Perl::Critic::Policy::Miscellanea::RequireRcsKeywords
     - Proc::ProcessTable
+    - Proc::Simple
     - Regexp::Common
     - SOAP::Lite
     - Statistics::Descriptive
     - String::ShellQuote
     - Sys::CPU
     - Test::Unit::Lite
+    - Test::Unit
     - Tie::IxHash
     - Time::Duration
     - XML::Generator


### PR DESCRIPTION
They're packaged for fedora. They're available on cpan. (Also, on cpan, Test::Unit's _actually getting new releases!_)