### PR TITLE
Add crontabs in the common packages list

### DIFF
--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -15,6 +15,7 @@ _farm_packages:
     - blktrace
     - crash
     - cryptsetup
+    - crontabs
     - device-mapper-event-devel
     - dwarves
     - elfutils


### PR DESCRIPTION
crontabs is no longer installed by default in Fedora.  This caused
problem in the farm/tasks/services.yml when that task restarts crond,
and ansible-playbook will fail to run successfully. Add crontabs
package in the common list so it will get installed.