### PR TITLE
[TECH-203] Changes need for F42 distro update

### DIFF
--- a/provisioning/roles/farm/tasks/config.yml
+++ b/provisioning/roles/farm/tasks/config.yml
@@ -62,3 +62,29 @@
     path: /var/lock/vdo
     state: absent
   become: yes
+
+- name: Create kdump directory
+  ansible.builtin.file:
+    path: /crash
+    state: directory
+  become: yes
+
+- name: Replace /var/crash with /crash
+  ansible.builtin.replace:
+    path: /etc/kdump.conf
+    regexp: '^path /var/crash'
+    replace: 'path /crash'
+  become: yes
+
+- name: Remove /var/crash
+  ansible.builtin.file:
+    path: /var/crash
+    state: absent
+  become: yes
+
+- name: link /crash to /var/crash
+  ansible.builtin.file:
+    src: /crash
+    dest: /var/crash
+    state: link
+  become: yes

--- a/provisioning/roles/nfs_server/tasks/export_nfs.yml
+++ b/provisioning/roles/nfs_server/tasks/export_nfs.yml
@@ -1,5 +1,12 @@
 ---
 - block:
+  - name: Start NFS Service
+    systemd:
+      name: nfs-server
+      state: restarted
+      enabled: true
+    become: yes
+
   - name: Export shared directories
     nfs_exports:
       name: "{{ item.src }} Share"
@@ -17,10 +24,3 @@
     vars:
       port: 2049/tcp
       open: true
-
-  - name: Start NFS Service
-    systemd:
-      name: nfs-server
-      state: restarted
-      enabled: true
-    become: yes


### PR DESCRIPTION
This request contains two changes for F42:

. kdump - In F42, kdump will not work if the crash dump path is not in the root partition. Change crash path to /varCrash, also link /var/crash to /varCrash.

. export_nfs - In ansibles module, export_nfs module fails with:
 "error": "Error updating exports: b\"exportfs: can't open /var/lib/nfs/etab for reading\\n\"",
if nfs-server is not already started.