### PR TITLE
Update get_perl_modules.yml for DNF output and new dependency

### DIFF
--- a/provisioning/library/get_perl_modules.yml
+++ b/provisioning/library/get_perl_modules.yml
@@ -52,9 +52,9 @@
       #   simple string, and "<pkg> in <string>" matches substrings of
       #   RPM names; we really need to do list operations.
       perl_rpms: "{{ dnf.stdout_lines
-                     | map('regex_replace', '[^ ]*\\.src ?: .*', '')
+                     | map('regex_replace', '[^ ]*\\.src( ?:|\t) .*', '')
                      | map('regex_replace', '^\\s*', '')
-                     | map('regex_search', '^perl-[^ :]*')
+                     | map('regex_search', '^perl-[^ :\t]*')
                      | select('string')
                      | map('regex_replace', '\\.[a-z0-9_]*$', '')
                      | unique


### PR DESCRIPTION
This commit updates get_perl_modules.yml to reflect changes in the latest stable Fedora release.
The regular expression used to parse the output of dnf has been updated to handle either the
 new tab (\t) delimiter or the colon (:) delimiter.
