### PR TITLE
Add vdo-test-tools package for installation

### DIFF
--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -38,6 +38,7 @@ _farm_packages:
     - targetcli
     - valgrind
     - valgrind-devel
+    - vdo-test-tools
     - xfsdump
     - yum-plugin-auto-update-debug-info
 


### PR DESCRIPTION
vdo-test-tools is required to fix the migration test failure referenced in PR #373.
https://github.com/dm-vdo/vdo-devel/pull/373