### PR TITLE
[VDO-6151] Install kdump-utils

### DIFF
--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -21,6 +21,7 @@ _farm_packages:
     - elfutils
     - gdb
     - iscsi-initiator-utils
+    - kdump-utils
     - kernel-debuginfo
     - kexec-tools
     - libaio


### PR DESCRIPTION
kdump is no longer installed by default in Fedora 43. This change installs the kdump-utils package to restore the service and /etc/kdump.conf.