### PR TITLE
fixes for newest ansible in Fedora

### DIFF
--- a/provisioning/group_vars/all/externals.yml
+++ b/provisioning/group_vars/all/externals.yml
@@ -4,7 +4,7 @@
 
 # The various software required for bunsen's internal functionality as well as
 # those bunsen will install on target machines during provisioning.
-_repo_prefix: "{{ is_rhel | ternary('epel', ansible_distribution | lower) }}"
+_repo_prefix: "{{ is_rhel | ternary('epel', ansible_facts['distribution'] | lower) }}"
 _distro_releasever: "{{ is_fedora | ternary('$releasever', target_distribution_major_number) }}"
 externals:
   # Resources for bunsen functionality.

--- a/provisioning/group_vars/all/settings.yml
+++ b/provisioning/group_vars/all/settings.yml
@@ -181,7 +181,7 @@ extra_user_ntp_servers: "{{ (user_ntp_servers | default([])) | unique }}"
 common_ntp_servers: "{{ [] + extra_user_ntp_servers }}"
 
 # User nfs mounts to mount.
-extra_user_nfs_mounts: "{{ user_nfs_mounts | default({}) }}"
+extra_user_nfs_mounts: "{{ user_nfs_mounts | default([]) }}"
 
 # User sshfs mounts to mount.
 extra_user_sshfs_mounts: "{{ user_sshfs_mounts | default([]) }}"

--- a/provisioning/group_vars/all/settings.yml
+++ b/provisioning/group_vars/all/settings.yml
@@ -24,26 +24,26 @@ default_retry_count: 3
 default_retry_delay: 20
 
 # The targeted platform.
-target_distribution_name: "{{ ansible_distribution }}"
-target_distribution_major_number: "{{ ansible_distribution_version.split('.')[0] }}"
+target_distribution_name: "{{ ansible_facts['distribution'] }}"
+target_distribution_major_number: "{{ ansible_facts['distribution_version'].split('.')[0] }}"
 
 # Fedora does not have a minor number, for it we use 0.
 target_distribution_minor_number: "
   {%- set minor = 0 -%}
   {%- if target_distribution_name != 'Fedora' -%}
-    {%- set minor = ansible_distribution_version.split('.')[1] %}
+    {%- set minor = ansible_facts['distribution_version'].split('.')[1] %}
   {%- endif -%}
   {{ minor }}"
 
 target_distribution_major_name: "{{target_distribution_name}}{{ target_distribution_major_number}}"
-target_distribution: "{{ target_distribution_name }}{{ ansible_distribution_version | regex_replace('\\.') }}"
+target_distribution: "{{ target_distribution_name }}{{ ansible_facts['distribution_version'] | regex_replace('\\.') }}"
 # Machine architecture family variables
-is_family_ppc: '{{ ansible_machine.startswith("ppc") }}'
-is_family_s390: '{{ ansible_machine.startswith("s390") }}'
-is_family_x86: '{{ (ansible_machine == "i386")
-                    or ansible_machine.startswith("x86") }}'
+is_family_ppc: '{{ ansible_facts["machine"].startswith("ppc") }}'
+is_family_s390: '{{ ansible_facts["machine"].startswith("s390") }}'
+is_family_x86: '{{ (ansible_facts["machine"] == "i386")
+                    or ansible_facts["machine"].startswith("x86") }}'
 # Machine architecture variables
-is_arch_s390x: '{{ ansible_machine == "s390x" }}'
+is_arch_s390x: '{{ ansible_facts["machine"] == "s390x" }}'
 
 # Checking for Fedora vs. CentOS/RHEL
 is_fedora: '{{target_distribution_name == "Fedora"}}'
@@ -75,7 +75,7 @@ distribution_repo_root_url: "
   {%- set root_url = (repo_root_url | default('')) -%}
   {%- if root_url == '' -%}
     {%- set root_url = query('released_repo_roots',
-                             (target_distribution, ansible_architecture)
+                             (target_distribution, ansible_facts['architecture'])
                               | join('/'))[0] -%}
   {%- endif -%}
   {{ root_url }}"

--- a/provisioning/library/firewall_port.yml
+++ b/provisioning/library/firewall_port.yml
@@ -3,7 +3,7 @@
 # the firewall for the change to take effect.
 #
 # Input vars:
-#   port: <N>[-<M>]/<tcp|udp>
+#   firewall_port: <N>[-<M>]/<tcp|udp>
 #   open: true => open, false => close
 
 # Open/close the specified ports in the firewall.
@@ -12,9 +12,9 @@
     service_facts:
 
   - block:
-    - name: Modify Firewall Port {{ port }}
+    - name: Modify Firewall Port {{ firewall_port }}
       firewalld:
-        port: "{{ port }}"
+        port: "{{ firewall_port }}"
         state: "{{ (open | bool) | ternary('enabled', 'disabled') }}"
         permanent: true
         offline: true

--- a/provisioning/library/get_perl_modules.yml
+++ b/provisioning/library/get_perl_modules.yml
@@ -30,7 +30,7 @@
 
   - name: List Perl module packages
     shell: |
-      {{ ansible_pkg_mgr }} search \
+      {{ ansible_facts['pkg_mgr'] }} search \
                  --disablerepo '*-debuginfo' \
                  {{ extra_repos | trim }} \
                  perl- 2>/dev/null
@@ -38,7 +38,7 @@
     changed_when: False
     register: dnf
 
-  - name: Parse and save {{ ansible_pkg_mgr }} list of Perl module packages
+  - name: Parse and save {{ ansible_facts['pkg_mgr'] }} list of Perl module packages
     set_fact:
       # regex_replace: Make lines with .src package names disappear.
       # regex_replace: Remove leading space.

--- a/provisioning/library/mount_nfs.yml
+++ b/provisioning/library/mount_nfs.yml
@@ -40,4 +40,4 @@
         that: "name in mount_points"
 
   vars:
-    mount_points: "{{ ansible_mounts | map(attribute='mount') | list }}"
+    mount_points: "{{ ansible_facts['mounts'] | map(attribute='mount') | list }}"

--- a/provisioning/library/mount_nfs.yml
+++ b/provisioning/library/mount_nfs.yml
@@ -5,7 +5,7 @@
 # attempt the mount, but if the mount fails, sometimes it will continue on. We
 # don't want that behavior, so we verify each mount.
 #
-# Input vars: name, src, extra_opts (optional)
+# Input vars: mount_point, src, extra_opts (optional)
 #   extra_opts gets workaround_nfs_mount_opts added
 #
 # Modifies:
@@ -15,9 +15,9 @@
 
     # "mount" module with state "mounted" creates the mount point
 
-    - name: "Mount {{ name }}"
+    - name: "Mount {{ mount_point }}"
       mount:
-        name: "{{ name }}"
+        path: "{{ mount_point }}"
         src: "{{ src }}"
         fstype: nfs
         state: mounted
@@ -25,7 +25,7 @@
       vars:
         opts: "{{ [extra_opts, workaround_nfs_mount_opts]
                    | select('defined')
-                   | reject('match', omit)
+                   | reject('equalto', omit)
                    | join(',') }}"
       become: yes
 
@@ -35,9 +35,9 @@
 
     # N.B.: Ansible's "mount" module will continue on if NFS mounts time out.
     # We want to flag such cases.
-    - name: "Verify mount of {{ name }}"
+    - name: "Verify mount of {{ mount_point }}"
       assert:
-        that: "name in mount_points"
+        that: "mount_point in mount_points"
 
   vars:
     mount_points: "{{ ansible_facts['mounts'] | map(attribute='mount') | list }}"

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -38,7 +38,7 @@
     - name: Copy bunsen log template and add image build date/time
       vars:
         image_date_time:
-          "{{ '%Y%m%d_%H%M%S' | strftime(ansible_date_time.epoch) }}"
+          "{{ '%Y%m%d_%H%M%S' | strftime(ansible_facts['date_time'].epoch) }}"
       template:
         src: bunsen.log
         dest: /var/log/bunsen.log
@@ -144,7 +144,7 @@
     - name: Update bunsen log with successful install date/time
       vars:
         install_date_time:
-          "{{ '%Y%m%d_%H%M%S' | strftime(ansible_date_time.epoch) }}"
+          "{{ '%Y%m%d_%H%M%S' | strftime(ansible_facts['date_time'].epoch) }}"
       lineinfile:
         path: /var/log/bunsen.log
         regexp: '^Install Date:'

--- a/provisioning/roles/base/tasks/create_permabuild.yml
+++ b/provisioning/roles/base/tasks/create_permabuild.yml
@@ -33,7 +33,7 @@
     assert:
       that: "'{{ item }}' not in mount_points"
     vars:
-      mount_points: "{{ ansible_mounts | map(attribute='mount') | list }}"
+      mount_points: "{{ ansible_facts['mounts'] | map(attribute='mount') | list }}"
     with_items: "{{ mounts }}"
 
   vars:

--- a/provisioning/roles/base/tasks/ntp.yml
+++ b/provisioning/roles/base/tasks/ntp.yml
@@ -58,5 +58,5 @@
   # XXX Otherwise, we're ignoring running services.
   when: (allow_environmental_ntp  | bool)
         and (not (is_rhel8_or_later_family | bool))
-        and (ansible_virtualization_role != 'guest')
+        and (ansible_facts['virtualization_role'] != 'guest')
         and (system_has_ntpd | bool)

--- a/provisioning/roles/base/tasks/ntpconfig.yml
+++ b/provisioning/roles/base/tasks/ntpconfig.yml
@@ -5,7 +5,7 @@
 # the ntpd and chronyd config files use the same syntax, so we can use common
 # tasks for both.
 #
-# Input variables: config_file daemon_name ntp_peers ntp_servers services
+# Input variables: config_file daemon_name ntp_peers ntp_servers ansible_facts.services
 # unit_name
 #
 # Sets variables: conf item
@@ -38,7 +38,7 @@
       systemd:
         name: "{{ unit_name }}"
         state: restarted
-      when: unit_name in services and services[unit_name].state == 'running'
+      when: unit_name in ansible_facts.services and ansible_facts.services[unit_name].state == 'running'
       # TODO: Don't restart if lineinfile didn't change anything.
       become: yes
 

--- a/provisioning/roles/base/vars/main.yml
+++ b/provisioning/roles/base/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 _base_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
   environment:
     - "{{ python_alternative }}"
 

--- a/provisioning/roles/early_packages/vars/main.yml
+++ b/provisioning/roles/early_packages/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 _early_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
   environment:
 
 _early_packages:

--- a/provisioning/roles/environment_facts/tasks/main.yml
+++ b/provisioning/roles/environment_facts/tasks/main.yml
@@ -16,9 +16,9 @@
       is_devvm: true
 
   - name: Get controller IPv4 info
-    local_action:
-      module: setup
+    setup:
       filter: ansible_default_ipv4
+    delegate_to: localhost
     delegate_facts: true
     run_once: true
 

--- a/provisioning/roles/environment_facts/tasks/main.yml
+++ b/provisioning/roles/environment_facts/tasks/main.yml
@@ -24,7 +24,7 @@
 
   - name: Get controller IPv4 address
     set_fact:
-      ansible_controller_ip: "{{ hostvars['localhost']['ansible_default_ipv4']['address'] }}"
+      ansible_controller_ip: "{{ hostvars['localhost']['ansible_facts']['default_ipv4']['address'] }}"
 
   - name: Include ansible controller as an NTP server
     set_fact:

--- a/provisioning/roles/farm/tasks/required_packages_file.yml
+++ b/provisioning/roles/farm/tasks/required_packages_file.yml
@@ -6,7 +6,7 @@
 
   - name: Check for packages with multiple versions
     assert:
-      that: "{{ dups|length == 0 }}"
+      that: "dups|length == 0"
       msg: "multiple versions of packages installed: \
               {{ dups | sort | join(', ') }}"
     vars:

--- a/provisioning/roles/farm/tasks/rsvp.yml
+++ b/provisioning/roles/farm/tasks/rsvp.yml
@@ -28,11 +28,7 @@
       - "{{ ((is_fedora | bool) or (is_rhel8_or_later_family | bool))
             | ternary('LINUX-VDO', 'ALL') }}"
       - "{{ is_performance_farm | bool | ternary('VDO-PMI', 'ALL') }}"
-    # For convenience above, we want to support something like the "omit"
-    # construct, but it doesn't work in simple list contexts; "omit" just
-    # expands to some magic cookie value which we still have to explicitly
-    # filter out.
-    class_list: "{{ classes | difference(omit) | join(',') }}"
+    class_list: "{{ classes | unique | join(',') }}"
   command: "rsvpclient --dhost {{ rsvp_server }} add {{ farm }} \
             --classes {{ class_list }}"
   become: yes

--- a/provisioning/roles/farm/tasks/rsvp.yml
+++ b/provisioning/roles/farm/tasks/rsvp.yml
@@ -1,14 +1,14 @@
 ---
 - name: Register with the RSVP server
   vars:
-    arch_class: "{{ ansible_architecture | upper }}"
+    arch_class: "{{ ansible_facts['architecture'] | upper }}"
     farm: "{{ inventory_hostname }}"
     os_class: "
-      {%- set distribution = ansible_distribution | upper -%}
+      {%- set distribution = ansible_facts['distribution'] | upper -%}
       {%- if distribution == 'REDHAT' -%}
-        RHEL{{ ansible_distribution_major_version }}
+        RHEL{{ ansible_facts['distribution_major_version'] }}
       {%- else -%}
-        {{ distribution }}{{ ansible_distribution_major_version }}
+        {{ distribution }}{{ ansible_facts['distribution_major_version'] }}
       {%- endif -%}"
     classes:
       - ALBIREO
@@ -41,7 +41,7 @@
   failed_when:
     - result.rc != 0
     - not (result.stderr is search(inventory_hostname ~ '.* already exists'))
-    - not (result.stderr is search(hostvars[inventory_hostname].ansible_fqdn ~ '.* already exists'))
+    - not (result.stderr is search(hostvars[inventory_hostname]['ansible_facts']['fqdn'] ~ '.* already exists'))
   changed_when: result.rc == 0
 
   # TODO: get the classes from the server.

--- a/provisioning/roles/farm/tasks/rsyslog.yml
+++ b/provisioning/roles/farm/tasks/rsyslog.yml
@@ -15,7 +15,7 @@
     regexp: '^module\(load=\"imjournal\"'
     line: 'module(load="imjournal" Ratelimit.Interval="0"'
     state: present
-  when: not (is_rhel_family and ansible_distribution_version.startswith('7'))
+  when: not (is_rhel_family and ansible_facts['distribution_version'].startswith('7'))
   become: yes
   register: ratelimit_result
 

--- a/provisioning/roles/farm/tasks/services.yml
+++ b/provisioning/roles/farm/tasks/services.yml
@@ -25,7 +25,7 @@
   # Open the athinfo tcp port so machines can reach the service.
   - include_tasks: "{{ playbook_dir }}/library/firewall_port.yml"
     vars:
-      port: 49155/tcp
+      firewall_port: 49155/tcp
       open: true
 
   - name: Make sure dkms is enabled

--- a/provisioning/roles/farm/tasks/storage-loop.yml
+++ b/provisioning/roles/farm/tasks/storage-loop.yml
@@ -30,7 +30,7 @@
         creates: "{{ destination_path }}"
 
     vars:
-      free_space_kb: "{{ (ansible_mounts
+      free_space_kb: "{{ (ansible_facts['mounts']
                           | selectattr('mount', 'match',
                                         ('^', mount_path, '$') | join)
                           | list)[0].size_available / 1024 }}"
@@ -70,7 +70,7 @@
 
   - name: Picking scratch volume group name
     set_fact:
-      "{{ volume_group }}": "{{ ansible_default_ipv4.macaddress.split(':')
+      "{{ volume_group }}": "{{ ansible_facts['default_ipv4'].macaddress.split(':')
                                 | join }}"
 
   vars:

--- a/provisioning/roles/farm/tasks/storage-targetd.yml
+++ b/provisioning/roles/farm/tasks/storage-targetd.yml
@@ -42,7 +42,7 @@
                      --name scratch_{{ macaddress }} \
                      --size {{ size }} --lun 0"
      vars:
-       macaddress: "{{ ansible_default_ipv4.macaddress.split(':') | join }}"
+       macaddress: "{{ ansible_facts['default_ipv4'].macaddress.split(':') | join }}"
        pool_labels: "{{ pool_output.stdout_lines[0].split() }}"
        all_pools: "\
            {%- set temp = [] -%}
@@ -79,7 +79,7 @@
     host_luns: "\
         {{ all_luns
            | selectattr('initiator_wwn', 'match',
-                        '^' + ansible_iscsi_iqn + '$')
+                        '^' + ansible_facts['iscsi_iqn'] + '$')
            | list }}"
   when: (host_luns | length) == 0
 

--- a/provisioning/roles/farm/tasks/storage.yml
+++ b/provisioning/roles/farm/tasks/storage.yml
@@ -35,18 +35,18 @@
         # distinguish the possibilities of nested virtualization. If it's not
         # available infer the machine is a virtualization guest if its
         # virtualization role is not 'host'.
-        guest_tech: "{{ ansible_virtualization_tech_guest
+        guest_tech: "{{ ansible_facts['virtualization_tech_guest']
                         | default(
-                            (ansible_virtualization_type != 'kvm')
+                            (ansible_facts['virtualization_type'] != 'kvm')
                             | ternary([],
-                                      (ansible_virtualization_role == 'host')
+                                      (ansible_facts['virtualization_role'] == 'host')
                                       | ternary([], ['kvm']))) }}"
         aux_disk: "{%- if 'kvm' in guest_tech -%}
                      vdb
                    {%- else -%}
                      sdb
                    {%- endif -%}"
-      when: aux_disk in ansible_devices.keys()
+      when: aux_disk in ansible_facts['devices'].keys()
 
     # Prepare the farm systems to use iscsi for testing.
     - block:
@@ -89,11 +89,11 @@
         # Assume any free space lives within the system volume group.
         - name: Using system volume group name for scratch storage
           set_fact:
-            scratch_vg: "{{ ansible_lvm.lvs['root'].vg }}"
+            scratch_vg: "{{ ansible_facts['lvm'].lvs['root'].vg }}"
             test_disk: ""
       when: (scratch_vg is not defined)
-              and ((ansible_lvm is defined) and (ansible_lvm is mapping))
-              and ('root' in ansible_lvm.lvs.keys())
+              and ((ansible_facts['lvm'] is defined) and (ansible_facts['lvm'] is mapping))
+              and ('root' in ansible_facts['lvm'].lvs.keys())
 
     - block:
         # scratch_vg not defined.
@@ -127,7 +127,7 @@
 
     - name: Setting scratch volume group name
       set_fact:
-        scratch_vg: "{{ ansible_default_ipv4.macaddress.split(':') | join }}"
+        scratch_vg: "{{ ansible_facts['default_ipv4'].macaddress.split(':') | join }}"
 
     when: use_storage_server and is_storage_client
 
@@ -251,7 +251,7 @@
            and (test_storage_device is not defined))
     become: yes
     vars:
-      free_gb: "{{ ansible_lvm.vgs[scratch_vg].free_g }}"
+      free_gb: "{{ ansible_facts['lvm'].vgs[scratch_vg].free_g }}"
 
   vars:
     vdo_scratch_min_gb: 100
@@ -259,8 +259,8 @@
     vdo_scratch_max_gb: 150
     existing_lvs: "
       {%- set tmp = {} -%}
-      {%- set lvs = ((ansible_lvm is defined) and (ansible_lvm is mapping))
-                    | ternary(ansible_lvm.lvs, {}) -%}
+      {%- set lvs = ((ansible_facts['lvm'] is defined) and (ansible_facts['lvm'] is mapping))
+                    | ternary(ansible_facts['lvm'].lvs, {}) -%}
       {%- for lv in lvs -%}
         {%- set x = tmp.update({ lvs[lv].vg+'/'+lv : 1 }) -%}
       {%- endfor -%}
@@ -274,5 +274,5 @@
     # kB required for u1 + vdo_scratch + slop
     required: "{{ ((farm_u1_size_gb | int) + vdo_scratch_min_gb + 1) * 1024 * 1024 }}"
     # mount point directory names
-    mount_points: "{{ ansible_mounts | map(attribute='mount') | list }}"
+    mount_points: "{{ ansible_facts['mounts'] | map(attribute='mount') | list }}"
 

--- a/provisioning/roles/farm/tasks/temp_fix_athinfo.yml
+++ b/provisioning/roles/farm/tasks/temp_fix_athinfo.yml
@@ -42,7 +42,7 @@
     line: '  isThirtyFive'
     state: present
   become: yes
-  when: isThirtyFiveIsMissing
+  when: isThirtyFiveIsMissing is changed
 
 # Check whether the 'ThirtyFive' is present in the $KNOWN_RELEASES.  If it's
 # missing, then register 'thirtyFiveIsMissing'.  Using check_mode: yes to
@@ -62,6 +62,6 @@
     regexp: 'ThirtyFour Rawhide\)'
     replace: 'ThirtyFour ThirtyFive Rawhide)'
   become: yes
-  when: thirtyFiveIsMissing
+  when: thirtyFiveIsMissing is changed
 
 

--- a/provisioning/roles/farm/vars/main.yml
+++ b/provisioning/roles/farm/vars/main.yml
@@ -3,8 +3,8 @@
 bunsen_user: "{{ bunsen_user_account }}"
 
 _farm_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
 
 farm_repositories: "{{ [] }}"
 

--- a/provisioning/roles/known_host/tasks/main.yml
+++ b/provisioning/roles/known_host/tasks/main.yml
@@ -3,7 +3,7 @@
 # Make certain we're known by our FQDN.
 - include_tasks: make_known.yml
   vars:
-    host: "{{ hostvars[inventory_hostname].ansible_fqdn }}"
+    host: "{{ hostvars[inventory_hostname]['ansible_facts']['fqdn'] }}"
 - include_tasks: make_known.yml
   vars:
     host: "{{ ansible_controller_ip }}"

--- a/provisioning/roles/nfs_client/tasks/import_nfs.yml
+++ b/provisioning/roles/nfs_client/tasks/import_nfs.yml
@@ -5,7 +5,7 @@
 # exclude directly mounting the NFS server export of the containing directory.
 - include_tasks: "{{ playbook_dir }}/library/mount_nfs.yml"
   vars:
-    name: "{{ item.dest }}"
+    mount_point: "{{ item.dest }}"
     src: "{{ item.server }}:{{ item.src }}"
   with_items: "
     {{ hostvars[nfs_server].nfs_exports | difference(user_homes) }}"

--- a/provisioning/roles/nfs_client/tasks/import_user_nfs.yml
+++ b/provisioning/roles/nfs_client/tasks/import_user_nfs.yml
@@ -3,7 +3,7 @@
   # Mount the user additional nfs mounts.
   - include_tasks: "{{ playbook_dir }}/library/mount_nfs.yml"
     vars:
-      name: "{{ item.dest }}"
+      mount_point: "{{ item.dest }}"
       src: "{{ item.server }}:{{ item.src }}"
       extra_opts: "{{ item.opts | default(omit) }}"
     with_items: "{{ nfs_mounts }}"

--- a/provisioning/roles/nfs_server/tasks/export_nfs.yml
+++ b/provisioning/roles/nfs_server/tasks/export_nfs.yml
@@ -22,5 +22,5 @@
   # Open the nfs tcp port in the firewall so machines can access our exports.
   - include_tasks: "{{ playbook_dir }}/library/firewall_port.yml"
     vars:
-      port: 2049/tcp
+      firewall_port: 2049/tcp
       open: true

--- a/provisioning/roles/rebooting_tasks/tasks/main.yml
+++ b/provisioning/roles/rebooting_tasks/tasks/main.yml
@@ -23,11 +23,11 @@
 - name: Check for older packages to be uninstalled
   command: dnf repoquery --installonly --latest-limit=-1 -q
   # Really, if packaging system is DNF vs Yum...
-  when: ansible_pkg_mgr == "dnf"
+  when: ansible_facts['pkg_mgr'] == "dnf"
   changed_when: False
   register: repoquery
 
 - name: Remove older kernels
   command: "dnf remove --assumeyes {{ repoquery.stdout }}"
   become: yes
-  when: (ansible_pkg_mgr == "dnf") and (repoquery.stdout != "")
+  when: (ansible_facts['pkg_mgr'] == "dnf") and (repoquery.stdout != "")

--- a/provisioning/roles/rebooting_tasks/vars/main.yml
+++ b/provisioning/roles/rebooting_tasks/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 _kernel_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
   environment:
 
 _kernel_packages:

--- a/provisioning/roles/repartition_home/tasks/main.yml
+++ b/provisioning/roles/repartition_home/tasks/main.yml
@@ -11,4 +11,4 @@
   # homedir, not ansible_user's.
   when: "'/home' in mount_points
           and 'home' in existing_lvs
-          and '/home' not in ansible_env['PWD']"
+          and '/home' not in ansible_facts['env']['PWD']"

--- a/provisioning/roles/repartition_home/vars/main.yml
+++ b/provisioning/roles/repartition_home/vars/main.yml
@@ -1,13 +1,13 @@
 ---
 #
-existing_lvs: "{%- if ((ansible_lvm is defined) and (ansible_lvm is mapping)) -%}
-                 {{ ansible_lvm.lvs.keys() | list }}
+existing_lvs: "{%- if ((ansible_facts['lvm'] is defined) and (ansible_facts['lvm'] is mapping)) -%}
+                 {{ ansible_facts['lvm'].lvs.keys() | list }}
                {%- else -%}
                  {{ [] }}
                {%- endif -%}"
-existing_vgs: "{%- if ((ansible_lvm is defined) and (ansible_lvm is mapping)) -%}
-                 {{ ansible_lvm.vgs.keys() | list }}
+existing_vgs: "{%- if ((ansible_facts['lvm'] is defined) and (ansible_facts['lvm'] is mapping)) -%}
+                 {{ ansible_facts['lvm'].vgs.keys() | list }}
                {%- else -%}
                  {{ [] }}
                {%- endif -%}"
-mount_points: "{{ ansible_mounts | map(attribute='mount') | list }}"
+mount_points: "{{ ansible_facts['mounts'] | map(attribute='mount') | list }}"

--- a/provisioning/roles/repos/vars/main.yml
+++ b/provisioning/roles/repos/vars/main.yml
@@ -1,8 +1,8 @@
 # Repository variables.
 ---
 _repos_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
   environment:
 
 _bunsen: "{{ externals['first-party']['bunsen']['host'] }}"
@@ -160,7 +160,7 @@ _repositories:
       gpgcheck: no
       sslverify: no
       baseurl: "{{ query('latest_repo_roots',
-                          (target_distribution, ansible_architecture)
+                          (target_distribution, ansible_facts['architecture'])
                             | join('/'))[0] }}/\
                   AppStream/$basearch/os/"
 
@@ -179,7 +179,7 @@ _repositories:
       gpgcheck: no
       sslverify: no
       baseurl: "{{ query('latest_repo_roots',
-                          (target_distribution, ansible_architecture)
+                          (target_distribution, ansible_facts['architecture'])
                             | join('/'))[0] }}/\
                   BaseOS/$basearch/os/"
 
@@ -205,7 +205,7 @@ _special_repositories:
       gpgcheck: no
       sslverify: no
       baseurl: "{{ query('special_released_repo_roots',
-                         (target_distribution, ansible_architecture)
+                         (target_distribution, ansible_facts['architecture'])
                          | join('/'))[0] }}/\
                   Everything/$basearch/os"
       cost: 1000000

--- a/provisioning/roles/resource/vars/main.yml
+++ b/provisioning/roles/resource/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 _resource_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
   environment:
 
 # Resource packages.

--- a/provisioning/roles/rsvp_server/tasks/make_server.yml
+++ b/provisioning/roles/rsvp_server/tasks/make_server.yml
@@ -26,7 +26,7 @@
   # Open the RSVPD tcp port so machines can reach the service.
   - include_tasks: "{{ playbook_dir }}/library/firewall_port.yml"
     vars:
-      port: "{{ port_number ~ '/tcp' }}"
+      firewall_port: "{{ port_number ~ '/tcp' }}"
       open: true
   vars:
     port_number: 1752 # The rsvp server we deploy listens on 1752.

--- a/provisioning/roles/special_packages/vars/main.yml
+++ b/provisioning/roles/special_packages/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 _special_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
   environment:
 
 # Require enabling special case repositories that have been installed.

--- a/provisioning/roles/storage_server/tasks/repartition.yml
+++ b/provisioning/roles/storage_server/tasks/repartition.yml
@@ -57,7 +57,7 @@
      become: yes
 
   vars:
-    mount_points: "{{ ansible_mounts | json_query('[*].mount') }}"
+    mount_points: "{{ ansible_facts['mounts'] | json_query('[*].mount') }}"
     existing_lvs: "
       {%- set tmp = {} -%}
       {%- for section in (lvm_report_result.stdout | from_json).report -%}

--- a/provisioning/roles/storage_server/tasks/targetd-server.yml
+++ b/provisioning/roles/storage_server/tasks/targetd-server.yml
@@ -26,7 +26,7 @@
       - { regexp: "^filesys_root:",
           line:   "filesys_root:  {{ filesys_root }}" }
     vars:
-      vgs: "{{ ansible_lvm.vgs }}"
+      vgs: "{{ ansible_facts['lvm'].vgs }}"
       vg_names: "{{ vgs.keys() | list }}"
       system_vg_name: "{{ vg_names[0] }}"
 

--- a/provisioning/roles/storage_server/tasks/targetd-server.yml
+++ b/provisioning/roles/storage_server/tasks/targetd-server.yml
@@ -49,7 +49,7 @@
 # Open the necessary iscsi ports so machines can reach the service.
 - include_tasks: "{{ playbook_dir }}/library/firewall_port.yml"
   vars:
-    port: "{{ item }}"
+    firewall_port: "{{ item }}"
     open: true
   with_items:
     - 3260/tcp  # iscsi itself

--- a/provisioning/roles/storage_server/vars/main.yml
+++ b/provisioning/roles/storage_server/vars/main.yml
@@ -1,8 +1,8 @@
 # Storage server variables.
 ---
 _server_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
   environment:
 
 # Server packages.

--- a/provisioning/roles/targetd_client/vars/main.yml
+++ b/provisioning/roles/targetd_client/vars/main.yml
@@ -1,8 +1,8 @@
 # Targetd client variables.
 ---
 _client_selection:
-  distribution: "{{ ansible_distribution + ansible_distribution_version }}"
-  architecture: "{{ ansible_machine }}"
+  distribution: "{{ ansible_facts['distribution'] + ansible_facts['distribution_version'] }}"
+  architecture: "{{ ansible_facts['machine'] }}"
   environment:
 
 # Client packages.


### PR DESCRIPTION
Ansible in Fedora 44 generates some new errors and warnings we didn't see in older versions -- variable names, unsupported syntax, etc. I turned Claude Code loose on them.